### PR TITLE
remove project dependency on pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smartiel/rustiq-core"
 
 
 [dependencies]
-pyo3 = { version = "0.18.2", features = ["extension-module"] }
 petgraph = "0.6.3"
 itertools = "0.10.5"
 rand = "0.8.5"

--- a/src/structures/clifford_circuit.rs
+++ b/src/structures/clifford_circuit.rs
@@ -1,4 +1,3 @@
-use pyo3::prelude::*;
 use rand::Rng;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CliffordGate {
@@ -52,7 +51,6 @@ impl CliffordGate {
         }
     }
 }
-#[pyclass]
 #[derive(Debug, Clone)]
 pub struct CliffordCircuit {
     pub nqbits: usize,

--- a/src/structures/metric.rs
+++ b/src/structures/metric.rs
@@ -1,6 +1,4 @@
 use super::CliffordCircuit;
-use pyo3::prelude::*;
-#[pyclass]
 #[derive(Debug, Clone)]
 pub enum Metric {
     COUNT,


### PR DESCRIPTION
This removes the project dependency on pyo3, which (as discussed) is the best path to integrate the project natively within Qiskit. A small update is also needed to the python-wrapper repository.