### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/routines/decoding.rs
+++ b/src/routines/decoding.rs
@@ -1,7 +1,7 @@
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 
-pub fn syndrome_decoding(parities: &Vec<Vec<bool>>, input_target: &Vec<bool>) -> Option<Vec<bool>> {
+pub fn syndrome_decoding(parities: &[Vec<bool>], input_target: &Vec<bool>) -> Option<Vec<bool>> {
     let mut target = input_target.clone();
     let mut solution = vec![false; parities.len()];
     let mut hweight = target.iter().filter(|a| **a).count();
@@ -40,18 +40,18 @@ pub fn syndrome_decoding(parities: &Vec<Vec<bool>>, input_target: &Vec<bool>) ->
     if true_target != *input_target {
         return None;
     }
-    return Some(solution);
+    Some(solution)
 }
 
-fn colop(parities: &mut Vec<Vec<bool>>, i: usize, j: usize) {
-    for k in 0..parities.len() {
-        parities[k][j] ^= parities[k][i];
+fn colop(parities: &mut [Vec<bool>], i: usize, j: usize) {
+    for row in parities.iter_mut() {
+        row[j] ^= row[i];
     }
 }
 
 fn shuffle_parities(
     parities: &mut Vec<Vec<bool>>,
-    target: &mut Vec<bool>,
+    target: &mut [bool],
     row_ech: bool,
 ) -> Vec<usize> {
     let n = parities.first().unwrap().len();
@@ -94,7 +94,7 @@ fn shuffle_parities(
     row_permutation
 }
 
-fn fix_permutation(solution: &Vec<bool>, permutation: &Vec<usize>) -> Vec<bool> {
+fn fix_permutation(solution: &[bool], permutation: &[usize]) -> Vec<bool> {
     let mut new_solution = vec![false; solution.len()];
     for (i, j) in permutation.iter().enumerate() {
         new_solution[*j] = solution[i];
@@ -103,7 +103,7 @@ fn fix_permutation(solution: &Vec<bool>, permutation: &Vec<usize>) -> Vec<bool> 
 }
 
 pub fn information_set_decoding(
-    input_parities: &Vec<Vec<bool>>,
+    input_parities: &[Vec<bool>],
     input_target: &Vec<bool>,
     ntries: usize,
     row_ech: bool,
@@ -111,10 +111,10 @@ pub fn information_set_decoding(
     let mut best_solution = None;
     let mut best_cost = None;
     for _ in 0..ntries {
-        let mut parities = input_parities.clone();
+        let mut parities = input_parities.to_owned();
         let mut target = input_target.clone();
         let permutation = shuffle_parities(&mut parities, &mut target, row_ech);
-        let solution = syndrome_decoding(&parities, &mut target);
+        let solution = syndrome_decoding(&parities, &target);
         if let Some(solution) = solution {
             let solution = fix_permutation(&solution, &permutation);
             let cost = solution.iter().filter(|a| **a).count();

--- a/src/routines/rotation_extraction.rs
+++ b/src/routines/rotation_extraction.rs
@@ -3,7 +3,7 @@
 use crate::structures::{PauliLike, Tableau};
 
 pub fn extract_rotations(
-    circuit: &Vec<(String, Vec<usize>)>,
+    circuit: &[(String, Vec<usize>)],
     nqubits: usize,
 ) -> (Vec<(bool, String)>, Tableau) {
     let mut clifford = Tableau::new(nqubits);

--- a/src/routines/rotation_optimization.rs
+++ b/src/routines/rotation_optimization.rs
@@ -4,7 +4,7 @@ use crate::structures::pauli_dag::{build_dag_from_pauli_set, get_front_layer, Da
 use crate::structures::{CliffordCircuit, CliffordGate, Parameter, PauliLike, PauliSet, Tableau};
 use std::collections::HashSet;
 
-fn update_rot_pi2<T: PauliLike>(axis: &String, k: i32, rest: &mut T, dagger: bool) {
+fn update_rot_pi2<T: PauliLike>(axis: &str, k: i32, rest: &mut T, dagger: bool) {
     let support: Vec<_> = (0..axis.len())
         .filter(|i| axis.chars().nth(*i).unwrap() != 'I')
         .collect();
@@ -51,7 +51,7 @@ fn update_rot_pi2<T: PauliLike>(axis: &String, k: i32, rest: &mut T, dagger: boo
 }
 
 fn zhang_internal(
-    rotations: &Vec<(String, Parameter)>,
+    rotations: &[(String, Parameter)],
     nqubits: usize,
     inverse_final_clifford: &mut Tableau,
 ) -> Vec<(String, Parameter)> {
@@ -65,7 +65,7 @@ fn zhang_internal(
     let mut rest = PauliSet::from_slice(&axes);
     let mut angles: Vec<Parameter> = Vec::new();
     let mut rot_index = 0;
-    while rest.len() > 0 {
+    while !rest.is_empty() {
         let (phase, axis) = rest.get(0);
         rest.pop();
         let angle = &mut future_angles[rot_index];
@@ -99,11 +99,11 @@ fn zhang_internal(
         rot_index += 1;
     }
     let mut output = Vec::new();
-    for i in 0..bucket.len() {
+    for (i, angle) in angles.iter().enumerate().take(bucket.len()) {
         let (phase, pstring) = bucket.get(i);
         assert!(!phase);
         if pstring.chars().any(|c| c != 'I') {
-            output.push((pstring, angles[i].clone()));
+            output.push((pstring, angle.clone()));
         }
     }
     output
@@ -163,12 +163,9 @@ impl MarkedPauliDag {
     }
 
     fn get_unmarked_xy(&self, rotation_index: usize) -> Option<usize> {
-        for qbit in 0..self.pauli_set.n {
-            if self.pauli_set.get_entry(qbit, rotation_index) & !self.marked.contains(&qbit) {
-                return Some(qbit);
-            }
-        }
-        return None;
+        (0..self.pauli_set.n).find(|&qbit| {
+            self.pauli_set.get_entry(qbit, rotation_index) & !self.marked.contains(&qbit)
+        })
     }
     fn has_unmarked_xy(&self, rotation_index: usize) -> bool {
         for qbit in 0..self.pauli_set.n {
@@ -176,7 +173,7 @@ impl MarkedPauliDag {
                 return true;
             }
         }
-        return false;
+        false
     }
     fn get_rotation_score(&self, rotation_index: usize) -> usize {
         if self.has_unmarked_xy(rotation_index) {
@@ -193,21 +190,20 @@ impl MarkedPauliDag {
                 score += 1;
             }
         }
-        return score;
+        score
     }
     /// Optimize a given rotation from the front layer of the PDAG
     fn optimize_rotation(&mut self, rotation_index: usize) {
         // Remove unmarked Z components:
         for qbit in 0..self.pauli_set.n {
-            if !self.marked.contains(&qbit) {
-                if self
+            if !self.marked.contains(&qbit)
+                && self
                     .pauli_set
                     .get_entry(qbit + self.pauli_set.n, rotation_index)
                     & !self.pauli_set.get_entry(qbit, rotation_index)
-                {
-                    self.pauli_set.set_entry(rotation_index, qbit, false, false);
-                    self.did_something = true;
-                }
+            {
+                self.pauli_set.set_entry(rotation_index, qbit, false, false);
+                self.did_something = true;
             }
         }
         // Fold X components onto a single unmarked qubit (if there is any)
@@ -281,13 +277,13 @@ impl MarkedPauliDag {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     fn pop_rest(&mut self) {
         loop {
             let front_layer = self.get_front_indices();
-            if front_layer.len() == 0 {
+            if front_layer.is_empty() {
                 break;
             }
             for rotation_index in front_layer.iter() {
@@ -302,19 +298,19 @@ impl MarkedPauliDag {
     }
 
     pub fn propagate(mut self) -> (PauliSet, Tableau, Vec<usize>, bool) {
-        while (&mut self).simplify_once() {}
+        while self.simplify_once() {}
         self.pop_rest();
-        return (
+        (
             self.output_pauli_set,
             self.final_clifford,
             self.output_rotations,
             self.did_something,
-        );
+        )
     }
 }
 
 pub fn full_initial_state_propagation(
-    rotations: &Vec<(String, Parameter)>,
+    rotations: &[(String, Parameter)],
 ) -> (Vec<(String, Parameter)>, Tableau) {
     let axes: Vec<_> = rotations.iter().map(|e| e.0.clone()).collect();
     let mut angles: Vec<_> = rotations.iter().map(|e| e.1.clone()).collect();
@@ -334,12 +330,12 @@ pub fn full_initial_state_propagation(
         }
     }
     let mut new_rotations = Vec::new();
-    for i in 0..pset.len() {
+    for (i, angle) in angles.iter_mut().enumerate().take(pset.len()) {
         let (phase, string) = pset.get(i);
         if phase {
-            angles[i].flip_sign();
+            angle.flip_sign();
         }
-        new_rotations.push((string, angles[i].clone()));
+        new_rotations.push((string, angle.clone()));
     }
-    return (new_rotations, final_clifford);
+    (new_rotations, final_clifford)
 }

--- a/src/structures/graph_state.rs
+++ b/src/structures/graph_state.rs
@@ -25,7 +25,7 @@ impl GraphState {
                 gs.adj[j][i] = entry;
             }
         }
-        return gs;
+        gs
     }
     pub fn from_adj(adj: Vec<Vec<bool>>) -> Self {
         let n = adj.len();

--- a/src/structures/isometry.rs
+++ b/src/structures/isometry.rs
@@ -63,7 +63,7 @@ impl IsometryTableau {
                 }
             }
         }
-        return iso;
+        iso
     }
     /// Put the full Tableau in column echelon form
     /// Warning: this method scratches the phases
@@ -81,8 +81,8 @@ impl IsometryTableau {
         }
         row_echelon(&mut table, self.k);
         let mut stabs = PauliSet::new(self.n + self.k);
-        for i in 0..self.k {
-            stabs.insert_vec_bool(&table[i], false);
+        for row in table.iter().take(self.k) {
+            stabs.insert_vec_bool(row, false);
         }
         let mut logicals = PauliSet::new(self.n + self.k);
         for i in 0..2 * self.n {
@@ -132,6 +132,6 @@ impl fmt::Display for IsometryTableau {
             "Logicals:\n{}Stabilizers:\n{}",
             self.logicals, self.stabilizers
         )?;
-        return fmt::Result::Ok(());
+        fmt::Result::Ok(())
     }
 }

--- a/src/structures/parameter.rs
+++ b/src/structures/parameter.rs
@@ -6,9 +6,18 @@ pub enum Parameter {
     Concrete(f64),
 }
 
+impl std::fmt::Display for Parameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Abstract(x) => f.write_str(x.as_str()),
+            Self::Concrete(x) => f.write_str(x.to_string().as_str()),
+        }
+    }
+}
+
 impl Parameter {
     pub fn zero() -> Self {
-        return Self::Concrete(0.0);
+        Self::Concrete(0.0)
     }
     pub fn is_zero(&self) -> bool {
         match self {
@@ -29,7 +38,7 @@ impl Parameter {
                 let y = x % (2. * std::f64::consts::PI);
                 let k = y.div_euclid(std::f64::consts::PI / 2.);
                 let rem = y % (std::f64::consts::PI / 2.);
-                return (Self::Concrete(rem), k as i32);
+                (Self::Concrete(rem), k as i32)
             }
         }
     }
@@ -52,12 +61,6 @@ impl Parameter {
             Self::Concrete(x) => Self::Abstract(x.to_string()),
         }
     }
-    pub fn to_string(&self) -> String {
-        match self {
-            Self::Abstract(x) => x.clone(),
-            Self::Concrete(x) => x.to_string(),
-        }
-    }
 }
 impl ops::Add<Parameter> for Parameter {
     type Output = Parameter;
@@ -69,7 +72,7 @@ impl ops::Add<Parameter> for Parameter {
             }
             _ => {
                 let mut new_expr = self.to_string();
-                new_expr.push_str("+");
+                new_expr.push('+');
                 new_expr.push_str(&_rhs.to_string());
                 Self::Abstract(new_expr)
             }
@@ -84,7 +87,7 @@ impl ops::AddAssign<Parameter> for Parameter {
             }
             _ => {
                 let mut new_expr = self.to_string();
-                new_expr.push_str("+");
+                new_expr.push('+');
                 new_expr.push_str(&_rhs.to_string());
                 *self = Self::Abstract(new_expr);
             }

--- a/src/structures/pauli.rs
+++ b/src/structures/pauli.rs
@@ -30,7 +30,7 @@ impl Pauli {
         let (their_z, their_x) = other.data.split_at(self.n);
         let p1 = my_z.iter().zip(their_x.iter()).map(|(a, b)| a & b);
         let p2 = my_x.iter().zip(their_z.iter()).map(|(a, b)| a & b);
-        return (p1.zip(p2).map(|(a, b)| a ^ b).filter(|a| *a).count() & 1) == 0;
+        (p1.zip(p2).map(|(a, b)| a ^ b).filter(|a| *a).count() & 1) == 0
     }
 }
 
@@ -52,7 +52,7 @@ impl ops::Mul<Pauli> for Pauli {
         for i in 0..2 * self.n {
             output.data[i] = self.data[i] ^ _rhs.data[i];
         }
-        output.phase = output.phase % 4;
+        output.phase %= 4;
         output
     }
 }

--- a/src/structures/pauli_dag.rs
+++ b/src/structures/pauli_dag.rs
@@ -15,14 +15,14 @@ pub fn build_dag_from_pauli_set(pauli_set: &PauliSet) -> Dag {
             }
         }
     }
-    return dag;
+    dag
 }
 
 /// Computes the list of operators that can be synthesized
 pub fn get_front_layer(dag: &Dag) -> Vec<NodeIndex> {
     return dag
         .node_indices()
-        .filter(|node| dag.neighbors(*node).collect::<Vec<_>>().len() == 0)
+        .filter(|node| dag.neighbors(*node).collect::<Vec<_>>().is_empty())
         .collect();
 }
 
@@ -67,13 +67,13 @@ impl PauliDag {
         loop {
             let node_count = self.dag.node_count();
             self.dag.retain_nodes(|graph, node_index| {
-                if graph.first_edge(node_index, Direction::Outgoing) == None {
+                if graph.first_edge(node_index, Direction::Outgoing).is_none() {
                     return self
                         .pauli_set
                         .support_size(*graph.node_weight(node_index).unwrap())
                         > 1;
                 }
-                return true;
+                true
             });
             if self.dag.node_count() == node_count {
                 break;
@@ -96,6 +96,6 @@ impl PauliDag {
         self.pauli_set.conjugate_with_circuit(&circuit);
         // Updating the front layer
         self.update_front_layer();
-        return circuit;
+        circuit
     }
 }

--- a/src/structures/pauli_set.rs
+++ b/src/structures/pauli_set.rs
@@ -7,11 +7,11 @@ use std::fmt;
 const WIDTH: usize = 64;
 
 fn get_stride(index: usize) -> usize {
-    return index / WIDTH;
+    index / WIDTH
 }
 
 fn get_offset(index: usize) -> usize {
-    return index % WIDTH;
+    index % WIDTH
 }
 
 /// A set of Pauli operators (module global phase)
@@ -54,7 +54,7 @@ impl PauliSet {
     }
     // Construction from a list of operators
     pub fn from_slice(data: &[String]) -> Self {
-        if data.len() == 0 {
+        if data.is_empty() {
             return Self::new(0);
         }
         let n = data.first().unwrap().len();
@@ -62,12 +62,17 @@ impl PauliSet {
         for piece in data {
             pset.insert(piece, false);
         }
-        return pset;
+        pset
     }
     /// Returns the number of operators stored in the set
     pub fn len(&self) -> usize {
-        return self.noperators;
+        self.noperators
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.noperators == 0
+    }
+
     /// Inserts a new Pauli operator in the set and returns its index
     pub fn insert(&mut self, axis: &str, phase: bool) -> usize {
         let stride = get_stride(self.noperators + self.start_offset);
@@ -84,27 +89,21 @@ impl PauliSet {
         // Setting the operator
         for (index, pauli) in axis.chars().enumerate() {
             match pauli {
-                'Z' => {
-                    self.data_array[index + self.n][stride] =
-                        self.data_array[index + self.n][stride] | (1 << offset)
-                }
-                'X' => {
-                    self.data_array[index][stride] = self.data_array[index][stride] | (1 << offset)
-                }
+                'Z' => self.data_array[index + self.n][stride] |= 1 << offset,
+                'X' => self.data_array[index][stride] |= 1 << offset,
                 'Y' => {
-                    self.data_array[index][stride] = self.data_array[index][stride] | (1 << offset);
-                    self.data_array[index + self.n][stride] =
-                        self.data_array[index + self.n][stride] | (1 << offset)
+                    self.data_array[index][stride] |= 1 << offset;
+                    self.data_array[index + self.n][stride] |= 1 << offset
                 }
                 _ => {}
             }
         }
         self.noperators += 1;
-        return self.noperators - 1;
+        self.noperators - 1
     }
 
     /// Inserts a new Pauli operator described as a vector of bool in the set and returns its index
-    pub fn insert_vec_bool(&mut self, axis: &Vec<bool>, phase: bool) -> usize {
+    pub fn insert_vec_bool(&mut self, axis: &[bool], phase: bool) -> usize {
         let stride = get_stride(self.noperators + self.start_offset);
         let offset = get_offset(self.noperators + self.start_offset);
         if stride == self.nstrides {
@@ -121,7 +120,7 @@ impl PauliSet {
             }
         }
         self.noperators += 1;
-        return self.noperators - 1;
+        self.noperators - 1
     }
     pub fn insert_pauli(&mut self, pauli: &Pauli) -> usize {
         self.insert_vec_bool(&pauli.data, pauli.phase == 2)
@@ -234,20 +233,20 @@ impl PauliSet {
     /// Get the operator at index `operator_index` as a `Pauli` object
     pub fn get_as_pauli(&self, operator_index: usize) -> Pauli {
         let (phase, data) = self.get_as_vec_bool(operator_index);
-        return Pauli::from_vec_bool(data, if phase { 2 } else { 0 });
+        Pauli::from_vec_bool(data, if phase { 2 } else { 0 })
     }
     /// Get a single entry of the PauliSet
     pub fn get_entry(&self, row: usize, col: usize) -> bool {
         let col = col + self.start_offset;
         let stride = get_stride(col);
         let offset = get_offset(col);
-        return ((self.data_array[row][stride] >> offset) & 1) != 0;
+        ((self.data_array[row][stride] >> offset) & 1) != 0
     }
     pub fn get_phase(&self, col: usize) -> bool {
         let col = col + self.start_offset;
         let stride = get_stride(col);
         let offset = get_offset(col);
-        return ((self.phases[stride] >> offset) & 1) != 0;
+        ((self.phases[stride] >> offset) & 1) != 0
     }
 
     pub fn get_i_factors(&self) -> Vec<u8> {
@@ -270,7 +269,7 @@ impl PauliSet {
                 ifact += 1;
             }
         }
-        return ifact % 4;
+        ifact % 4
     }
     /// Get the inverse Z output of the tableau (assuming the PauliSet is a Tableau, i.e. has exactly 2n operators storing X1...Xn Z1...Zn images)
     pub fn get_inverse_z(&self, qbit: usize) -> (bool, String) {
@@ -293,7 +292,7 @@ impl PauliSet {
                 }
             }
         }
-        return (self.get_phase(qbit + self.n), pstring);
+        (self.get_phase(qbit + self.n), pstring)
     }
     /// Get the inverse X output of the tableau (assuming the PauliSet is a Tableau, i.e. has exactly 2n operators storing X1...Xn Z1...Zn images)
     pub fn get_inverse_x(&self, qbit: usize) -> (bool, String) {
@@ -318,14 +317,14 @@ impl PauliSet {
                 }
             }
         }
-        return ((cy % 2 != 0), pstring);
+        ((cy % 2 != 0), pstring)
     }
 
     /// Returns the sum mod 2 of the logical AND of a row with an external vector of booleans
-    pub fn and_row_acc(&self, row: usize, vec: &Vec<bool>) -> bool {
+    pub fn and_row_acc(&self, row: usize, vec: &[bool]) -> bool {
         let mut output = false;
-        for i in 0..2 * self.n {
-            output ^= self.get_entry(row, i) & vec[i];
+        for (i, item) in vec.iter().enumerate().take(2 * self.n) {
+            output ^= self.get_entry(row, i) & item;
         }
         output
     }
@@ -334,7 +333,7 @@ impl PauliSet {
     pub fn equals(&self, i: usize, j: usize) -> bool {
         let (_, vec1) = self.get_as_vec_bool(i);
         let (_, vec2) = self.get_as_vec_bool(j);
-        return vec1 == vec2;
+        vec1 == vec2
     }
 
     /// Checks if two operators in the set commute
@@ -347,7 +346,7 @@ impl PauliSet {
                 count_diff += 1;
             }
         }
-        return (count_diff % 2) == 0;
+        (count_diff % 2) == 0
     }
 
     // Returns the support of the operator (i.e. the list of qbit indices on which the operator acts non trivially)
@@ -379,7 +378,7 @@ impl PauliSet {
                 count += 1;
             }
         }
-        return count;
+        count
     }
 
     /*
@@ -392,7 +391,7 @@ impl PauliSet {
         let (target_row, source_row) = if i < j {
             (right.get_mut(0).unwrap(), left.get(i).unwrap())
         } else {
-            (left.get_mut(j).unwrap(), right.get(0).unwrap())
+            (left.get_mut(j).unwrap(), right.first().unwrap())
         };
 
         for (v1, v2) in source_row.iter().zip(target_row.iter_mut()) {
@@ -447,16 +446,14 @@ impl PauliSet {
             if ns == nstart_stride {
                 count -= self.start_offset;
             }
-            if ns == self.nstrides - 1 {
-                if value == 0 {
-                    count -= 64 - get_offset(self.start_offset + self.noperators);
-                }
+            if ns == self.nstrides - 1 && value == 0 {
+                count -= 64 - get_offset(self.start_offset + self.noperators);
             }
             if value != 0 {
                 return count;
             }
         }
-        return count;
+        count
     }
     /// Sorts the set by support size
     pub fn support_size_sort(&mut self) {
@@ -483,9 +480,9 @@ impl fmt::Display for PauliSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for i in 0..self.len() {
             let (phase, string) = self.get(i);
-            write!(f, "{}{}\n", if phase { "-" } else { "+" }, string)?;
+            writeln!(f, "{}{}", if phase { "-" } else { "+" }, string)?;
         }
-        write!(f, "\n")
+        writeln!(f)
     }
 }
 

--- a/src/synthesis/clifford/codiagonalization/common.rs
+++ b/src/synthesis/clifford/codiagonalization/common.rs
@@ -15,7 +15,7 @@ pub fn build_table(pauli_set: &PauliSet) -> (Vec<Vec<bool>>, Vec<Vec<bool>>) {
     (table_z, table_x)
 }
 
-fn swap_rows(table: &mut Vec<Vec<bool>>, rows: &Vec<usize>) {
+fn swap_rows(table: &mut Vec<Vec<bool>>, rows: &[usize]) {
     let mut new_table = Vec::new();
     for j in rows.iter() {
         new_table.push(table[*j].clone());
@@ -23,14 +23,14 @@ fn swap_rows(table: &mut Vec<Vec<bool>>, rows: &Vec<usize>) {
     *table = new_table;
 }
 
-pub fn make_full_rank(
-    pauli_set: &PauliSet,
-) -> (
+type FullRank = (
     CliffordCircuit,
     Vec<usize>,
     usize,
     (Vec<Vec<bool>>, Vec<Vec<bool>>),
-) {
+);
+
+pub fn make_full_rank(pauli_set: &PauliSet) -> FullRank {
     let (mut t_z, mut t_x) = build_table(pauli_set);
     let mut circuit = CliffordCircuit::new(pauli_set.n);
     for i in 0..pauli_set.n {
@@ -46,8 +46,8 @@ pub fn make_full_rank(
     let mut fr_rows = Vec::new();
     let mut wit = Vec::new();
     let mut rk = 0;
-    for i in 0..pauli_set.n {
-        wit.push(t_x[i].clone());
+    for (i, item) in t_x.iter().enumerate().take(pauli_set.n) {
+        wit.push(item.clone());
         if f2_rank(&wit) == rk + 1 {
             fr_rows.push(i);
             rk += 1;
@@ -63,9 +63,9 @@ pub fn make_full_rank(
     swap_rows(&mut t_x, &fr_rows);
     swap_rows(&mut t_z, &fr_rows);
     diagonalize(&mut t_x, &mut t_z, rk);
-    return (circuit, fr_rows, rk, (t_z, t_x));
+    (circuit, fr_rows, rk, (t_z, t_x))
 }
-pub fn permute_circuit(circuit: &CliffordCircuit, permutation: &Vec<usize>) -> CliffordCircuit {
+pub fn permute_circuit(circuit: &CliffordCircuit, permutation: &[usize]) -> CliffordCircuit {
     let mut permuted_circuit = CliffordCircuit::new(circuit.nqbits);
     for gate in circuit.gates.iter() {
         match gate {

--- a/src/synthesis/clifford/codiagonalization/subset_wise.rs
+++ b/src/synthesis/clifford/codiagonalization/subset_wise.rs
@@ -4,7 +4,7 @@ use crate::routines::f2_linalg::{f2_rank, rowop};
 use crate::structures::{CliffordCircuit, CliffordGate, PauliSet};
 use std::collections::HashSet;
 
-fn vec_xor(v1: &mut Vec<bool>, v2: &Vec<bool>) {
+fn vec_xor(v1: &mut [bool], v2: &[bool]) {
     for (a, b) in v1.iter_mut().zip(v2.iter()) {
         *a ^= *b;
     }
@@ -13,7 +13,7 @@ fn vec_xor(v1: &mut Vec<bool>, v2: &Vec<bool>) {
 fn greedy_reduce(
     z_table: &mut Vec<Vec<bool>>,
     x_table: &mut Vec<Vec<bool>>,
-    qubits: &Vec<usize>,
+    qubits: &[usize],
 ) -> (usize, CliffordCircuit) {
     let mut min_weight = z_table.len() + 1;
     let mut min_index = None;
@@ -55,10 +55,7 @@ fn greedy_reduce(
     panic!("Something went wrong, no qbit was diagonalized");
 }
 
-fn find_rank_nm1(
-    z_part: &mut Vec<Vec<bool>>,
-    x_part: &mut Vec<Vec<bool>>,
-) -> Option<CliffordCircuit> {
+fn find_rank_nm1(z_part: &mut [Vec<bool>], x_part: &mut Vec<Vec<bool>>) -> Option<CliffordCircuit> {
     // We want to turn x_part into a rank k-1 matrix (or at least attempt to)
     // We are allowed to:
     // * swap row i of Z with row i of X (H gate)
@@ -83,7 +80,7 @@ fn find_rank_nm1(
             }
             down /= 3;
         }
-        let rk = f2_rank(&x_part);
+        let rk = f2_rank(x_part);
         if rk == x_part.len() - 1 {
             return Some(circuit);
         }
@@ -111,7 +108,7 @@ fn find_rank_nm1(
 fn update_rank_nm1(
     z_table: &mut Vec<Vec<bool>>,
     x_table: &mut Vec<Vec<bool>>,
-    subset: &Vec<usize>,
+    subset: &[usize],
 ) -> CliffordCircuit {
     for k in subset.iter() {
         let mut target = x_table[*k].clone();
@@ -138,7 +135,7 @@ fn update_rank_nm1(
 fn subset_codiag(
     z_table: &mut Vec<Vec<bool>>,
     x_table: &mut Vec<Vec<bool>>,
-    subset: &Vec<usize>,
+    subset: &[usize],
 ) -> Option<CliffordCircuit> {
     let mut z_part = Vec::new();
     let mut x_part = Vec::new();
@@ -150,7 +147,7 @@ fn subset_codiag(
     }
     let circuit = find_rank_nm1(&mut z_part, &mut x_part);
     match circuit {
-        None => return None,
+        None => None,
         Some(circuit) => {
             let mut output_circuit = CliffordCircuit::new(z_table.len());
             for gate in circuit.gates.iter() {
@@ -170,14 +167,14 @@ fn subset_codiag(
             }
             let cnot_circuit = update_rank_nm1(z_table, x_table, subset);
             output_circuit.extend_with(&cnot_circuit);
-            return Some(output_circuit);
+            Some(output_circuit)
         }
     }
 }
 
 fn is_qbit_trivial(
-    z_table: &mut Vec<Vec<bool>>,
-    x_table: &mut Vec<Vec<bool>>,
+    z_table: &mut [Vec<bool>],
+    x_table: &mut [Vec<bool>],
     qbit: usize,
 ) -> Option<CliffordCircuit> {
     let observed: HashSet<_> = z_table[qbit]
@@ -202,7 +199,7 @@ fn is_qbit_trivial(
         }
         return Some(CliffordCircuit::new(z_table.len()));
     }
-    return None;
+    None
 }
 
 fn enumerate_subsets(qubits: &HashSet<usize>, size: usize) -> Vec<Vec<usize>> {
@@ -250,14 +247,18 @@ fn step(
             }
         }
     }
-    return greedy_reduce(z_table, x_table, &qubits.iter().map(|e| *e).collect());
+    greedy_reduce(
+        z_table,
+        x_table,
+        &qubits.iter().copied().collect::<Vec<_>>(),
+    )
 }
 
 pub fn codiagonalize_subsetwise(pauli_set: &PauliSet, k: usize) -> CliffordCircuit {
-    let (mut z_table, mut x_table) = build_table(&pauli_set);
+    let (mut z_table, mut x_table) = build_table(pauli_set);
     let mut circuit = CliffordCircuit::new(pauli_set.n);
     let mut qbits: HashSet<usize> = (0..pauli_set.n).collect();
-    while qbits.len() > 0 {
+    while !qbits.is_empty() {
         let (qbit, piece) = step(&mut z_table, &mut x_table, &mut qbits, k);
         assert!(qbits.remove(&qbit));
         circuit.extend_with(&piece);

--- a/src/synthesis/clifford/graph_state/depth.rs
+++ b/src/synthesis/clifford/graph_state/depth.rs
@@ -4,7 +4,7 @@ use crate::structures::pauli_like::PauliLike;
 use petgraph::algo::maximum_matching;
 use petgraph::prelude::*;
 
-fn score_matrix(graph: &mut GraphState, qubits_used: &Vec<bool>) -> Vec<Vec<i32>> {
+fn score_matrix(graph: &mut GraphState, qubits_used: &[bool]) -> Vec<Vec<i32>> {
     let base_value: i32 = graph.count_ones() as i32;
     let mut scores = vec![vec![-1; graph.n]; graph.n];
     for i in 0..graph.n {
@@ -19,7 +19,7 @@ fn score_matrix(graph: &mut GraphState, qubits_used: &Vec<bool>) -> Vec<Vec<i32>
     scores
 }
 
-fn pick_best_operation(scores: &Vec<Vec<i32>>) -> (i32, (usize, usize)) {
+fn pick_best_operation(scores: &[Vec<i32>]) -> (i32, (usize, usize)) {
     let mut best_score = 0;
     let mut best_qubits: (usize, usize) = (0, 0);
     for i in 0..scores.len() {
@@ -30,10 +30,10 @@ fn pick_best_operation(scores: &Vec<Vec<i32>>) -> (i32, (usize, usize)) {
             }
         }
     }
-    return (best_score, best_qubits);
+    (best_score, best_qubits)
 }
 
-pub fn get_czs(graph: &GraphState, qubits_used: &Vec<bool>) -> CliffordCircuit {
+pub fn get_czs(graph: &GraphState, qubits_used: &[bool]) -> CliffordCircuit {
     let mut mgraph: UnGraph<(), i32> = UnGraph::new_undirected();
     for _ in 0..graph.n {
         mgraph.add_node(());
@@ -82,5 +82,5 @@ pub fn synthesize_graph_state_depth(input_graph: &GraphState) -> CliffordCircuit
         graph.conjugate_with_circuit(&cz_circuit);
     }
 
-    return circuit.dagger();
+    circuit.dagger()
 }

--- a/src/synthesis/clifford/graph_state/utils.rs
+++ b/src/synthesis/clifford/graph_state/utils.rs
@@ -26,7 +26,7 @@ fn make_x_full_rank(z_part: &mut Matrix, x_part: &mut Matrix) -> CliffordCircuit
             circuit.gates.push(CliffordGate::H(i));
         }
     }
-    assert_eq!(f2_rank(&x_part), x_part.len());
+    assert_eq!(f2_rank(x_part), x_part.len());
     circuit
 }
 

--- a/src/synthesis/clifford/isometry/common.rs
+++ b/src/synthesis/clifford/isometry/common.rs
@@ -27,7 +27,7 @@ pub fn extract_abcd(isometry: &IsometryTableau) -> (Matrix, Matrix, Matrix, Matr
             d[j][i] = vec[j];
         }
     }
-    return (a, b, c, d);
+    (a, b, c, d)
 }
 
 fn make_b_full_rank(
@@ -47,7 +47,7 @@ fn make_b_full_rank(
             circuit.gates.push(CliffordGate::H(i));
         }
     }
-    assert_eq!(f2_rank(&b), b.len());
+    assert_eq!(f2_rank(b), b.len());
     circuit
 }
 
@@ -58,7 +58,7 @@ pub fn decompose(isometry: &IsometryTableau) -> (Matrix, Matrix, Matrix, Cliffor
     let b_k: Matrix = inv_b.clone().drain(..isometry.n).collect();
     let gn = mult_f2(&a, &inv_b);
     let gk = mult_f2(&inv_b, &d).drain(..isometry.n).collect();
-    return (gk, gn, b_k, piece);
+    (gk, gn, b_k, piece)
 }
 
 pub fn fix_phases(isometry: &IsometryTableau, circuit: &mut CliffordCircuit) {

--- a/src/synthesis/clifford/isometry/depth.rs
+++ b/src/synthesis/clifford/isometry/depth.rs
@@ -8,14 +8,8 @@ fn allowed_row_ops(n: usize, k: usize) -> Vec<(usize, usize)> {
     let mut moves = Vec::new();
     for i in 0..n + k {
         for j in 0..n + k {
-            if i != j {
-                if i > j {
-                    moves.push((j, i));
-                } else {
-                    if i >= n {
-                        moves.push((j, i));
-                    }
-                }
+            if i != j && (i > j || i >= n) {
+                moves.push((j, i));
             }
         }
     }
@@ -25,8 +19,8 @@ fn allowed_row_ops(n: usize, k: usize) -> Vec<(usize, usize)> {
 fn score_matrix(
     graph: &mut GraphState,
     b_matrix: &mut Matrix,
-    qubits_used: &Vec<bool>,
-    moves: &Vec<(usize, usize)>,
+    qubits_used: &[bool],
+    moves: &[(usize, usize)],
 ) -> Vec<Vec<i32>> {
     let base_value: i32 = (graph.count_ones() + count_ones_except_diag(b_matrix)) as i32;
     let mut scores = vec![vec![-1; b_matrix.len()]; b_matrix.len()];
@@ -40,13 +34,10 @@ fn score_matrix(
             graph.cnot(*i, *j);
         }
     }
-    return scores;
+    scores
 }
 
-fn pick_best_operation(
-    scores: &Vec<Vec<i32>>,
-    moves: &Vec<(usize, usize)>,
-) -> (i32, (usize, usize)) {
+fn pick_best_operation(scores: &[Vec<i32>], moves: &[(usize, usize)]) -> (i32, (usize, usize)) {
     let mut best_score = 0;
     let mut best_qubits: (usize, usize) = (0, 0);
     for (i, j) in moves.iter() {
@@ -55,7 +46,7 @@ fn pick_best_operation(
             best_qubits = (*j, *i);
         }
     }
-    return (best_score, best_qubits);
+    (best_score, best_qubits)
 }
 fn graph_state_and_b_synthesis(graph: &mut GraphState, b_matrix: &mut Matrix) -> CliffordCircuit {
     let row_ops = allowed_row_ops(
@@ -83,7 +74,7 @@ fn graph_state_and_b_synthesis(graph: &mut GraphState, b_matrix: &mut Matrix) ->
             qubits_used[control] = true;
             qubits_used[target] = true;
         }
-        let cz_circuit = get_czs(&graph, &qubits_used);
+        let cz_circuit = get_czs(graph, &qubits_used);
         output.extend_with(&cz_circuit);
         graph.conjugate_with_circuit(&cz_circuit);
     }
@@ -92,7 +83,7 @@ fn graph_state_and_b_synthesis(graph: &mut GraphState, b_matrix: &mut Matrix) ->
 }
 
 pub fn isometry_depth_synthesis(isometry: &IsometryTableau) -> CliffordCircuit {
-    let (g_k, g_n, b, h_circuit) = decompose(&isometry);
+    let (g_k, g_n, b, h_circuit) = decompose(isometry);
     let (mut l, u, _, ops) = lu_facto(&transpose(&b));
     let mut output = CliffordCircuit::new(isometry.n + isometry.k);
     let mut gn_as_gs = GraphState::from_adj(g_n);

--- a/src/synthesis/clifford/isometry/synthesis.rs
+++ b/src/synthesis/clifford/isometry/synthesis.rs
@@ -17,7 +17,7 @@ pub fn isometry_synthesis(
         Metric::DEPTH => isometry_depth_synthesis(isometry),
     };
     fix_phases(isometry, &mut result);
-    return result;
+    result
 }
 
 #[cfg(test)]

--- a/src/synthesis/pauli_network/greedy_order_preserving.rs
+++ b/src/synthesis/pauli_network/greedy_order_preserving.rs
@@ -9,10 +9,10 @@ pub fn pauli_network_synthesis_no_permutation(
 ) -> CliffordCircuit {
     let mut dag = PauliDag::from_pauli_set(axes.clone());
     let mut circuit = CliffordCircuit::new(dag.pauli_set.n);
-    while dag.front_layer.len() > 0 {
-        circuit.extend_with(&dag.single_step_synthesis(&metric, skip_sort));
+    while !dag.front_layer.is_empty() {
+        circuit.extend_with(&dag.single_step_synthesis(metric, skip_sort));
     }
-    return circuit;
+    circuit
 }
 
 #[cfg(test)]

--- a/src/synthesis/pauli_network/greedy_pauli_network.rs
+++ b/src/synthesis/pauli_network/greedy_pauli_network.rs
@@ -63,7 +63,7 @@ pub fn chunk_to_circuit(
             _ => {}
         }
     }
-    return circuit_piece;
+    circuit_piece
 }
 
 pub fn conjugate_with_chunk(
@@ -150,11 +150,11 @@ fn single_synthesis_step_count(bucket: &mut PauliSet) -> CliffordCircuit {
     let mut best_args: [usize; 2] = [0, 0];
     let support = bucket.get_support(0);
     for i1 in 0..support.len() {
-        for i2 in  0..i1 {
+        for i2 in 0..i1 {
             let qbit1 = support[i1];
             let qbit2 = support[i2];
-            let init_id_count_1 = bucket.count_id(qbit1) ;
-            let init_id_count_2 = bucket.count_id(qbit2) ;
+            let init_id_count_1 = bucket.count_id(qbit1);
+            let init_id_count_2 = bucket.count_id(qbit2);
             for chunk in ALL_CHUNKS {
                 // conjugating with the chunk
                 conjugate_with_chunk(bucket, &chunk, qbit1, qbit2, false);
@@ -166,17 +166,17 @@ fn single_synthesis_step_count(bucket: &mut PauliSet) -> CliffordCircuit {
                 let score = if score_1 == 0 { score_2 } else { score_1 };
                 if score > max_score {
                     max_score = score;
-                    best_chunk = chunk.clone();
+                    best_chunk = chunk;
                     best_args = [qbit1, qbit2];
                 }
                 conjugate_with_chunk(bucket, &chunk, qbit1, qbit2, true);
             }
         }
     }
-   
+
     conjugate_with_chunk(bucket, &best_chunk, best_args[0], best_args[1], false);
 
-    return chunk_to_circuit(&best_chunk, best_args[0], best_args[1], bucket.n);
+    chunk_to_circuit(&best_chunk, best_args[0], best_args[1], bucket.n)
 }
 
 fn build_graph(bucket: &mut PauliSet) -> (UnGraph<(), i32>, HashMap<(usize, usize), Chunk>) {
@@ -199,7 +199,7 @@ fn build_graph(bucket: &mut PauliSet) -> (UnGraph<(), i32>, HashMap<(usize, usiz
                 let score: i32 = new_count as i32 - init_id_count as i32;
                 if score > max_score {
                     max_score = score;
-                    best_chunk = chunk.clone();
+                    best_chunk = chunk;
                 }
                 best_chunks.insert((qbit1, qbit2), best_chunk);
                 // undoing the conjugation
@@ -211,7 +211,7 @@ fn build_graph(bucket: &mut PauliSet) -> (UnGraph<(), i32>, HashMap<(usize, usiz
             }
         }
     }
-    return (graph, best_chunks);
+    (graph, best_chunks)
 }
 
 fn single_synthesis_step_depth(bucket: &mut PauliSet) -> CliffordCircuit {
@@ -229,14 +229,14 @@ fn single_synthesis_step_depth(bucket: &mut PauliSet) -> CliffordCircuit {
         conjugate_with_chunk(bucket, &chunk, qbit1.index(), qbit2.index(), false);
     }
 
-    return circuit_piece;
+    circuit_piece
 }
 
 pub fn single_synthesis_step(bucket: &mut PauliSet, metric: &Metric) -> CliffordCircuit {
-    return match metric {
+    match metric {
         Metric::COUNT => single_synthesis_step_count(bucket),
         Metric::DEPTH => single_synthesis_step_depth(bucket),
-    };
+    }
 }
 
 pub fn pauli_network_synthesis(
@@ -244,7 +244,7 @@ pub fn pauli_network_synthesis(
     metric: &Metric,
     skip_sort: bool,
 ) -> CliffordCircuit {
-    if bucket.len() == 0 {
+    if bucket.is_empty() {
         return CliffordCircuit::new(0);
     }
 
@@ -255,16 +255,16 @@ pub fn pauli_network_synthesis(
         if !skip_sort {
             bucket.support_size_sort();
         }
-        while bucket.support_size(0) <= 1 && bucket.len() > 0 {
+        while bucket.support_size(0) <= 1 && !bucket.is_empty() {
             bucket.pop();
         }
-        if bucket.len() == 0 {
+        if bucket.is_empty() {
             break;
         }
-        let circuit_piece = single_synthesis_step(bucket, &metric);
+        let circuit_piece = single_synthesis_step(bucket, metric);
         output.extend_with(&circuit_piece);
     }
-    return output;
+    output
 }
 
 #[cfg(test)]

--- a/src/synthesis/pauli_network/synthesis.rs
+++ b/src/synthesis/pauli_network/synthesis.rs
@@ -24,7 +24,7 @@ fn permute_input(pset: &mut PauliSet) -> Vec<usize> {
     permutation
 }
 
-fn permute_circuit(circuit: &CliffordCircuit, permutation: &Vec<usize>) -> CliffordCircuit {
+fn permute_circuit(circuit: &CliffordCircuit, permutation: &[usize]) -> CliffordCircuit {
     let mut output = CliffordCircuit::new(circuit.nqbits);
     for gate in circuit.gates.iter() {
         match gate {
@@ -53,7 +53,7 @@ pub fn check_circuit(input: &[String], circuit: &CliffordCircuit) {
         }
     }
     for gate in circuit.gates.iter() {
-        bucket.conjugate_with_gate(&gate);
+        bucket.conjugate_with_gate(gate);
 
         for i in 0..bucket.len() {
             if bucket.support_size(i) == 1 {
@@ -97,10 +97,10 @@ pub fn greedy_pauli_network(
     if fix_clifford {
         let mut tableau = IsometryTableau::new(circuit.nqbits, 0);
         tableau.conjugate_with_circuit(&circuit.dagger());
-        let fix = isometry_synthesis(&mut tableau, &metric, 100);
+        let fix = isometry_synthesis(&tableau, metric, 100);
         circuit.extend_with(&fix);
     }
-    return circuit;
+    circuit
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This commit is a fairly mechanical fixing of all the clippy warnings in the repository. Most of the time the clippy suggestions are just directly applied. Some of the issues clippy pointed out probably could benefit from a deeper refactoring around some of the types and function signatures to reduce copying, owned types, and allocations necessary, but that can be saved for a follow up PR. In a follow up commit we should add a ci job that runs `cargo fmt --check` and `cargo clippy` to enforce the style and lint as part of pre-merge checking.