### PR TITLE
Add GHA CI job to run build, fmt, clippy, and test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+---
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test --verbose


### PR DESCRIPTION
This commit adds a CI job to github actions that will run pre and post merge on any branch to run cargo build, cargo fmt, cargo clippy, and cargo test. This will ensure that any proposed change to rustiq-core will pass all of these checks to ensure the repo can always build, pass all the tests, and is following standard best practices for rust development.

To start this is only testing on linux, but we can expand the testing matrix to cover other operating systems and platforms pretty easily if needed.

We shouldn't add this CI job until #2 merges because CI won't pass clippy without that.