### PR TITLE
Speedup Pauli network synthesis code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 *.egg*
 misc
 **.so
+.idea/

--- a/src/structures/pauli_dag.rs
+++ b/src/structures/pauli_dag.rs
@@ -79,7 +79,7 @@ impl PauliDag {
 
     /// Remove synthesized operations from the front layer and update
     /// the front layer accordingly.
-    fn update_front_nodes(&mut self) {
+    pub(crate) fn update_front_nodes(&mut self) {
         let mut unprocessed = self.front_nodes.clone();
         self.front_nodes = Vec::new();
         // For some reason this is less performant than cloning:

--- a/src/structures/pauli_dag.rs
+++ b/src/structures/pauli_dag.rs
@@ -86,8 +86,7 @@ impl PauliDag {
         // let mut unprocessed: Vec<NodeIndex> = Vec::new();
         // std::mem::swap(&mut self.front_nodes, &mut unprocessed);
 
-        while !unprocessed.is_empty() {
-            let node_index = unprocessed.pop().unwrap();
+        while let Some(node_index) = unprocessed.pop() {
             if !self.is_synthesized(node_index) {
                 self.front_nodes.push(node_index);
             } else {
@@ -99,14 +98,13 @@ impl PauliDag {
                         unprocessed.push(successor);
                     }
                 }
-
             }
         }
     }
 
     /// Returns true if fully processed
     pub fn fully_processed(&self) -> bool {
-        self.front_nodes.len() == 0
+        self.front_nodes.is_empty()
     }
 
     /// Performs a single synthesis step
@@ -136,6 +134,5 @@ impl PauliDag {
 
         // Updating the front layer
         self.update_front_nodes();
-
     }
 }

--- a/src/structures/pauli_dag.rs
+++ b/src/structures/pauli_dag.rs
@@ -1,6 +1,8 @@
 use super::{CliffordCircuit, Metric, PauliLike, PauliSet};
 use crate::synthesis::pauli_network::greedy_pauli_network::single_synthesis_step;
 use petgraph::prelude::*;
+use std::collections::HashMap;
+
 pub type Dag = DiGraph<usize, ()>;
 
 /// Constructs an anti-commutation Dag from a set of operators
@@ -31,27 +33,33 @@ pub struct PauliDag {
     pub pauli_set: PauliSet,
     /// The dag structure
     pub dag: Dag,
-    /// A Pauli set containing only the front layer of the set
-    /// (operators pairwise commute in this set)
-    pub front_layer: PauliSet,
+    /// The front layer of (unprocessed) DAG nodes
+    /// (corresponding Pauli operators pairwise commute)
+    pub front_nodes: Vec<NodeIndex>,
+    /// Stores the number of (unprocessed) predecessors for each node
+    pub in_degree: HashMap<NodeIndex, usize>,
 }
 
 impl PauliDag {
     /// Constructs a PauliDag from a PauliSet
     pub fn from_pauli_set(pauli_set: PauliSet) -> Self {
-        let nqbits = pauli_set.n;
         let dag = build_dag_from_pauli_set(&pauli_set);
-        let indices_front_layer = get_front_layer(&dag);
 
-        let mut front_layer = PauliSet::new(nqbits);
-        for index in indices_front_layer {
-            let (phase, pstring) = pauli_set.get(*dag.node_weight(index).unwrap());
-            front_layer.insert(&pstring, phase);
+        let mut in_degree: HashMap<NodeIndex, usize> = HashMap::with_capacity(dag.node_count());
+        let mut front_nodes: Vec<NodeIndex> = Vec::new();
+        for node_index in dag.node_indices() {
+            let node_in_degree = dag.neighbors_directed(node_index, Incoming).count();
+            in_degree.insert(node_index, node_in_degree);
+            if node_in_degree == 0 {
+                front_nodes.push(node_index);
+            }
         }
+
         Self {
             pauli_set,
             dag,
-            front_layer,
+            front_nodes,
+            in_degree,
         }
     }
 
@@ -60,42 +68,61 @@ impl PauliDag {
         Self::from_pauli_set(PauliSet::from_slice(axes))
     }
 
-    fn update_front_layer(&mut self) {
-        // Popping the trivial operators from the front_layer
-        self.front_layer.clear();
-        // Removing nodes that were synthesized at this round
-        loop {
-            let node_count = self.dag.node_count();
-            self.dag.retain_nodes(|graph, node_index| {
-                if graph.first_edge(node_index, Direction::Outgoing) == None {
-                    return self
-                        .pauli_set
-                        .support_size(*graph.node_weight(node_index).unwrap())
-                        > 1;
+    /// Checks if the Pauli corresponding to `node_index` is synthesized,
+    /// that is, if its support is of size <= 1
+    fn is_synthesized(&self, node_index: NodeIndex) -> bool {
+        self.pauli_set
+            .support_size(*self.dag.node_weight(node_index).unwrap())
+            <= 1
+    }
+
+    /// Remove synthesized operations from the front layer and update
+    /// the front layer accordingly.
+    fn update_front_nodes(&mut self) {
+        let mut unprocessed = self.front_nodes.clone();
+        self.front_nodes = Vec::new();
+        // For some reason this is less performant than cloning:
+        // let mut unprocessed: Vec<NodeIndex> = Vec::new();
+        // std::mem::swap(&mut self.front_nodes, &mut unprocessed);
+
+        while !unprocessed.is_empty() {
+            let node_index = unprocessed.pop().unwrap();
+            if !self.is_synthesized(node_index) {
+                self.front_nodes.push(node_index);
+            } else {
+                // the node can be removed, check which of its successors are now
+                // front nodes
+                for successor in self.dag.neighbors_directed(node_index, Outgoing) {
+                    self.in_degree.entry(successor).and_modify(|d| *d -= 1);
+                    if self.in_degree[&successor] == 0 {
+                        unprocessed.push(successor);
+                    }
                 }
-                return true;
-            });
-            if self.dag.node_count() == node_count {
-                break;
             }
-        }
-        // Updating the front layer bucket
-        for index in get_front_layer(&self.dag) {
-            let (phase, pstring) = self.pauli_set.get(*self.dag.node_weight(index).unwrap());
-            self.front_layer.insert(&pstring, phase);
         }
     }
 
     /// Performs a single synthesis step
     pub fn single_step_synthesis(&mut self, metric: &Metric, skip_sort: bool) -> CliffordCircuit {
-        if !skip_sort {
-            self.front_layer.support_size_sort();
+        // Creating a fresh PauliSet from the nodes in the front layer
+        let mut front_layer: PauliSet = PauliSet::new(self.pauli_set.n);
+        for index in &self.front_nodes {
+            let (phase, pstring) = self.pauli_set.get(*self.dag.node_weight(*index).unwrap());
+            front_layer.insert(&pstring, phase);
         }
-        let circuit = single_synthesis_step(&mut self.front_layer, metric);
+
+        if !skip_sort {
+            front_layer.support_size_sort();
+        }
+
+        let circuit = single_synthesis_step(&mut front_layer, metric);
+
         // Updating the global set of operators
         self.pauli_set.conjugate_with_circuit(&circuit);
+
         // Updating the front layer
-        self.update_front_layer();
-        return circuit;
+        self.update_front_nodes();
+
+        circuit
     }
 }

--- a/src/structures/pauli_set.rs
+++ b/src/structures/pauli_set.rs
@@ -339,15 +339,15 @@ impl PauliSet {
 
     /// Checks if two operators in the set commute
     pub fn commute(&self, i: usize, j: usize) -> bool {
-        let (_, vec1) = self.get_as_vec_bool(i);
-        let (_, vec2) = self.get_as_vec_bool(j);
         let mut count_diff = 0;
         for k in 0..self.n {
-            if (vec1[k] & vec2[k + self.n]) ^ (vec1[k + self.n] & vec2[k]) {
+            if (self.get_entry(k, i) & self.get_entry(k + self.n, j))
+                ^ (self.get_entry(k + self.n, i) & self.get_entry(k, j))
+            {
                 count_diff += 1;
             }
         }
-        return (count_diff % 2) == 0;
+        (count_diff % 2) == 0
     }
 
     // Returns the support of the operator (i.e. the list of qbit indices on which the operator acts non trivially)

--- a/src/synthesis/pauli_network/greedy_order_preserving.rs
+++ b/src/synthesis/pauli_network/greedy_order_preserving.rs
@@ -10,6 +10,7 @@ pub fn pauli_network_synthesis_no_permutation(
     let mut circuit = CliffordCircuit::new(axes.n);
 
     let mut dag = PauliDag::from_pauli_set(axes.clone());
+    dag.update_front_nodes();
     while !dag.fully_processed() {
         dag.single_step_synthesis(&metric, skip_sort, &mut circuit);
     }

--- a/src/synthesis/pauli_network/greedy_order_preserving.rs
+++ b/src/synthesis/pauli_network/greedy_order_preserving.rs
@@ -9,7 +9,7 @@ pub fn pauli_network_synthesis_no_permutation(
 ) -> CliffordCircuit {
     let mut dag = PauliDag::from_pauli_set(axes.clone());
     let mut circuit = CliffordCircuit::new(dag.pauli_set.n);
-    while dag.front_layer.len() > 0 {
+    while dag.front_nodes.len() > 0 {
         circuit.extend_with(&dag.single_step_synthesis(&metric, skip_sort));
     }
     return circuit;

--- a/src/synthesis/pauli_network/greedy_order_preserving.rs
+++ b/src/synthesis/pauli_network/greedy_order_preserving.rs
@@ -12,7 +12,7 @@ pub fn pauli_network_synthesis_no_permutation(
     let mut dag = PauliDag::from_pauli_set(axes.clone());
     dag.update_front_nodes();
     while !dag.fully_processed() {
-        dag.single_step_synthesis(&metric, skip_sort, &mut circuit);
+        dag.single_step_synthesis(metric, skip_sort, &mut circuit);
     }
     circuit
 }

--- a/src/synthesis/pauli_network/greedy_order_preserving.rs
+++ b/src/synthesis/pauli_network/greedy_order_preserving.rs
@@ -7,12 +7,14 @@ pub fn pauli_network_synthesis_no_permutation(
     metric: &Metric,
     skip_sort: bool,
 ) -> CliffordCircuit {
+    let mut circuit = CliffordCircuit::new(axes.n);
+
     let mut dag = PauliDag::from_pauli_set(axes.clone());
-    let mut circuit = CliffordCircuit::new(dag.pauli_set.n);
-    while dag.front_nodes.len() > 0 {
-        circuit.extend_with(&dag.single_step_synthesis(&metric, skip_sort));
+    while !dag.fully_processed() {
+        dag.single_step_synthesis(&metric, skip_sort, &mut circuit);
     }
-    return circuit;
+
+    circuit
 }
 
 #[cfg(test)]

--- a/src/synthesis/pauli_network/synthesis.rs
+++ b/src/synthesis/pauli_network/synthesis.rs
@@ -121,7 +121,7 @@ mod tests {
         let nshuffles = 0;
 
         let _result = greedy_pauli_network(
-            &mut operator_sequence,
+            &operator_sequence,
             &metric,
             preserve_order,
             nshuffles,
@@ -143,7 +143,7 @@ mod tests {
         let nshuffles = 0;
 
         let result = greedy_pauli_network(
-            &mut operator_sequence,
+            &operator_sequence,
             &metric,
             preserve_order,
             nshuffles,
@@ -199,7 +199,7 @@ mod tests {
         let nshuffles = 10;
 
         let result = greedy_pauli_network(
-            &mut operator_sequence,
+            &operator_sequence,
             &metric,
             preserve_order,
             nshuffles,

--- a/src/synthesis/pauli_network/synthesis.rs
+++ b/src/synthesis/pauli_network/synthesis.rs
@@ -48,7 +48,7 @@ pub fn check_circuit(input: &[String], circuit: &CliffordCircuit) {
     let mut hit_map: HashSet<usize> = HashSet::new();
     let mut bucket = PauliSet::from_slice(input);
     for i in 0..bucket.len() {
-        if bucket.support_size(i) == 1 {
+        if bucket.support_size(i) == 0 || bucket.support_size(i) == 1 {
             hit_map.insert(i);
         }
     }
@@ -70,7 +70,7 @@ pub fn check_circuit(input: &[String], circuit: &CliffordCircuit) {
 }
 
 pub fn greedy_pauli_network(
-    operator_sequence: &mut PauliSet,
+    operator_sequence: &PauliSet,
     metric: &Metric,
     preserve_order: bool,
     nshuffles: usize,


### PR DESCRIPTION
This PR includes several low-hanging performance improvements for pauli network synthesis.

### Reasoning about PauliDag's front layer

Instead of recalculating the front layer in the DAG every time, we use a vector `in_degree` to store the number of unprocessed predecessors for every node in the DAG. In addition, the nodes with no unprocessed predecessors are kept in a vector `front_nodes`. Note that we no longer remove nodes from a DAG, instead we consider them as processed and decrease the `in_degree` of their successors by 1.

Unfortunately, the output of the new method is not identical to the one before, probably because the order of Pauli operators in the Pauli set passed to `single_synthesis_step` may be different (even after sorting by support size). Empirically, this makes the results a bit better in some cases and a bit worse in some others.

### Speeding up `PauliSet.commute`

For some testcases a considerable time is spent is `PauliSet.commute`, due to its calling `get_as_vec_bool` and allocating/deallocating vectors. It is significantly faster to just use `get_entry` method. In addition, we do not need to return or reason about Pauli phases.

### Benchmarking

Here are two illustrative benchmarks from `benchpress`:
* test 35: old method: `19.4` seconds, new method: `0.3` seconds
* test 66: old method: `129.1` seconds, new method `13.7` seconds
(with run arguments: `metric = &Metric::COUNT`, `preserve_order = true`, `nshuffles = 0`, `skip_sort = false`, `fix_clifford = false`)


### Other comments

The `PauliDag`'s function `single_step_synthesis` now gets the synthesized circuit as an argument, and adds new gates to it directly. I think this makes the code a bit cleaner.

One additional small fix is for the function `check_circuit` to correctly account for all-identity Paulis. Note that this checking function is still not quite correct, since it only checks that each Pauli is eventually transformed to a single-qubit rotation, but ignores the commutativity between Paulis. 

In the future we could extend the synthesis functions to return a full circuit, consisting both of Clifford gates and Pauli operations. This would make Rustiq integration in Qiskit significantly simpler. I actually have the code for this already.

This PR is not based on #2 or #3 (so some of the changed code could introduce new clippy warnings).