### PR TITLE
fix directions in PauliDAG

### DIFF
--- a/src/structures/pauli_dag.rs
+++ b/src/structures/pauli_dag.rs
@@ -12,7 +12,7 @@ pub fn build_dag_from_pauli_set(pauli_set: &PauliSet) -> Dag {
     for i in 0..pauli_set.len() {
         for j in 0..i {
             if !pauli_set.commute(i, j) {
-                dag.add_edge(node_indices[i], node_indices[j], ());
+                dag.add_edge(node_indices[j], node_indices[i], ());
             }
         }
     }


### PR DESCRIPTION
In the recent changes I have introduced the most silliest error (sorry!):  when building a `PauliDag` from an ordered sequence of rotations, the edge directions were reversed, which led to synthesizing the rotations in the reverse order.

Unfortunately, the `check_circuit` function did not pick up on this as it only checks that every rotation is hit at some point, but does not look at the order this happens.

This tiny PR fixes the problem.