### PR TITLE
Add Pauli measurements

### DIFF
--- a/src/structures/isometry.rs
+++ b/src/structures/isometry.rs
@@ -8,29 +8,30 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct IsometryTableau {
-    pub n: usize,
-    pub k: usize,
+    pub n: usize, // Number of logical operators
+    pub k: usize, // Number of stabilizers
     pub logicals: PauliSet,
     pub stabilizers: PauliSet,
 }
 
 impl IsometryTableau {
+    // Construct an IsometryTableau with n logical qubits and k ancilla in |0>.
     pub fn new(n: usize, k: usize) -> Self {
         let mut logicals = PauliSet::new(n + k);
         for i in 0..n {
             let mut vecbool = vec![false; 2 * n + 2 * k];
-            vecbool[i] = true;
+            vecbool[i] = true; // Logical operator X_i -> X_i
             logicals.insert_vec_bool(&vecbool, false);
         }
         for i in 0..n {
             let mut vecbool = vec![false; 2 * n + 2 * k];
-            vecbool[i + n + k] = true;
+            vecbool[i + n + k] = true; // Logical operator Z_i -> Z_i
             logicals.insert_vec_bool(&vecbool, false);
         }
         let mut stabilizers = PauliSet::new(n + k);
         for i in 0..k {
             let mut vecbool = vec![false; 2 * n + 2 * k];
-            vecbool[n + k + n + i] = true;
+            vecbool[n + k + n + i] = true; // stabilizer Z_{n+i}
             stabilizers.insert_vec_bool(&vecbool, false);
         }
         IsometryTableau {
@@ -128,27 +129,31 @@ impl PauliLike for IsometryTableau {
 }
 
 impl MeasurementLike for IsometryTableau {
-    fn measure(&mut self, meas_string: Pauli) {
+    fn measure(&mut self, basis: &Pauli) {
         // Find an anti-commuting stabilizer, if there isn't, you measured data!
         // Todo: generalize to allow measurements of data
-        let (corr_i, _) = (0..self.stabilizers.len())
-            .find_position(|i| !self.stabilizers.get_as_pauli(*i).commutes(&meas_string))
-            .unwrap();
+        let corr_opt = (0..self.stabilizers.len())
+            .find_position(|i| !self.stabilizers.get_as_pauli(*i).commutes(basis));
 
-        let correction = self.stabilizers.get_as_pauli(corr_i);
-        for j in corr_i + 1..self.stabilizers.len() {
-            let other = self.stabilizers.get_as_pauli(j);
-            if !other.commutes(&meas_string) {
-                self.stabilizers.mul_pauli(j, &correction);
+        if let Some((corr_i, _)) = corr_opt {
+            let correction = self.stabilizers.get_as_pauli(corr_i);
+            self.stabilizers.set_pauli(corr_i, basis);
+            for j in corr_i + 1..self.stabilizers.len() {
+                let other = self.stabilizers.get_as_pauli(j);
+                if !other.commutes(basis) {
+                    self.stabilizers.mul_pauli(j, &correction);
+                }
             }
-        }
 
-        // Now correct logicals
-        for j in 0..self.logicals.len() {
-            let other = self.logicals.get_as_pauli(j);
-            if !other.commutes(&meas_string) {
-                self.logicals.mul_pauli(j, &correction);
+            // Now correct logicals
+            for j in 0..self.logicals.len() {
+                let other = self.logicals.get_as_pauli(j);
+                if !other.commutes(basis) {
+                    self.logicals.mul_pauli(j, &correction);
+                }
             }
+        } else {
+            panic!("No anti-commuting stabilizer, so you are measuring data. This has not been implemented.")
         }
     }
 }
@@ -161,5 +166,59 @@ impl fmt::Display for IsometryTableau {
             self.logicals, self.stabilizers
         )?;
         fmt::Result::Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_measure_x2() {
+        let mut tableau = IsometryTableau::new(1, 1);
+        let no_qubit = vec![0];
+        let qubit2 = vec![2];
+        let x2 = Pauli {
+            n: 2,
+            x_paulis: qubit2.clone(),
+            z_paulis: no_qubit.clone(),
+            sign: false,
+        };
+        let z2 = Pauli {
+            n: 2,
+            x_paulis: no_qubit,
+            z_paulis: qubit2,
+            sign: false,
+        };
+        tableau.measure(&x2);
+
+        let mut ref_tableau = IsometryTableau::new(1, 1);
+        ref_tableau.stabilizers.set_pauli(0, &x2);
+        assert_eq!(tableau, ref_tableau);
+    }
+
+    #[test]
+    fn test_measure_x1x2() {
+        let mut tableau = IsometryTableau::new(1, 1);
+        let no_qubit = vec![0];
+        let qubit12 = vec![3];
+        let x12 = Pauli {
+            n: 2,
+            x_paulis: qubit12.clone(),
+            z_paulis: no_qubit.clone(),
+            sign: false,
+        };
+        let z12 = Pauli {
+            n: 2,
+            x_paulis: no_qubit,
+            z_paulis: qubit12,
+            sign: false,
+        };
+        tableau.measure(&x12);
+
+        let mut ref_tableau = IsometryTableau::new(1, 1);
+        ref_tableau.stabilizers.set_pauli(0, &x12);
+        ref_tableau.logicals.set_pauli(1, &z12);
+        assert_eq!(tableau, ref_tableau);
     }
 }

--- a/src/structures/measurement_like.rs
+++ b/src/structures/measurement_like.rs
@@ -1,0 +1,6 @@
+use super::Pauli;
+
+/// This trait should be implemented by any struct that can be measured by a Pauli operator
+pub trait MeasurementLike {
+    fn measure(&mut self, p: Pauli);
+}

--- a/src/structures/measurement_like.rs
+++ b/src/structures/measurement_like.rs
@@ -2,5 +2,6 @@ use super::Pauli;
 
 /// This trait should be implemented by any struct that can be measured by a Pauli operator
 pub trait MeasurementLike {
-    fn measure(&mut self, p: Pauli);
+    // Measure in the given basis
+    fn measure(&mut self, basis: &Pauli);
 }

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -4,6 +4,7 @@ pub mod clifford_circuit;
 pub mod graph_state;
 pub mod hardware;
 pub mod isometry;
+pub mod measurement_like;
 pub mod metric;
 pub mod parameter;
 pub mod pauli;

--- a/src/structures/pauli.rs
+++ b/src/structures/pauli.rs
@@ -83,10 +83,10 @@ impl Pauli {
     }
 }
 
-impl ops::Mul<Pauli> for Pauli {
+impl ops::Mul<&Pauli> for &Pauli {
     type Output = Pauli;
 
-    fn mul(self, rhs: Pauli) -> Pauli {
+    fn mul(self, rhs: &Pauli) -> Self::Output {
         assert_eq!(self.n, rhs.n);
         let mut output = Pauli::new(self.n);
         output.phase = self.phase + rhs.phase;

--- a/src/structures/pauli_set.rs
+++ b/src/structures/pauli_set.rs
@@ -160,20 +160,14 @@ impl PauliSet {
     pub fn set_entry(&mut self, operator_index: usize, qbit: usize, x_part: bool, z_part: bool) {
         let stride = get_stride(operator_index + self.start_offset);
         let offset = get_offset(operator_index + self.start_offset);
-        if x_part != (1 == (self.data_array[qbit][stride] >> offset) & 1) {
-            self.data_array[qbit][stride] ^= 1 << offset;
-        }
-        if z_part != (1 == (self.data_array[qbit + self.n][stride] >> offset) & 1) {
-            self.data_array[qbit + self.n][stride] ^= 1 << offset;
-        }
+        set_bit(&mut self.data_array[qbit][stride], offset, x_part);
+        set_bit(&mut self.data_array[qbit + self.n][stride], offset, z_part);
     }
 
     pub fn set_raw_entry(&mut self, row: usize, col: usize, value: bool) {
         let stride = get_stride(col);
         let offset = get_offset(col);
-        if value != (1 == (self.data_array[row][stride] >> offset) & 1) {
-            self.data_array[row][stride] ^= 1 << offset;
-        }
+        set_bit(&mut self.data_array[row][stride], offset, value);
     }
 
     /// Clears the data of the Pauli set

--- a/src/structures/pauli_set.rs
+++ b/src/structures/pauli_set.rs
@@ -134,9 +134,9 @@ impl PauliSet {
     // }
 
     // Multiply a Pauli in the table by another Pauli
-    pub fn mul_pauli(&mut self, operator_index: usize, pauli: Pauli) {
+    pub fn mul_pauli(&mut self, operator_index: usize, pauli: &Pauli) {
         let self_p = self.get_as_pauli(operator_index);
-        let new_p = self_p * pauli;
+        let new_p = &self_p * pauli;
 
         for qubit in 0..self.n {
             self.set_entry(


### PR DESCRIPTION
I wrote an implementation of Pauli-basis measurements that anti-commute with at least one of the stabilizers. Along the way, I improved the Pauli API so it is easier to specify Paulis. When doing measurements, working with the row-major ordering in PauliSet is quite difficult, so I hope things are still correct. To help with this I implemented some helper methods on PauliSet.