### PR TITLE
Bump petgraph and itertools versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ documentation = "https://docs.rs/rustiq-core"
 homepage = "https://github.com/smartiel/rustiq-core"
 
 [dependencies]
-petgraph = "0.6.3"
-itertools = "0.10.5"
+petgraph = "0.7"
+itertools = "0.14"
 rand = "0.8.5"


### PR DESCRIPTION
This commit bumps the versions of petgraph and itertools in the cargo.toml. These new versions seem to be fully compatible with how rustiq-core was using them.