### PR TITLE
Fix clippy failure on latest nightly

### DIFF
--- a/src/structures/pauli_set.rs
+++ b/src/structures/pauli_set.rs
@@ -129,7 +129,7 @@ impl PauliSet {
     pub fn set_phase(&mut self, col: usize, phase: bool) {
         let stride = get_stride(col);
         let offset = get_offset(col);
-        if phase != ((self.phases[stride] >> offset & 1) != 0) {
+        if phase != (((self.phases[stride] >> offset) & 1) != 0) {
             self.phases[stride] ^= 1 << offset;
         }
     }


### PR DESCRIPTION
In newer nightly and the current rust beta channel there is a new clippy rule that suggests wrapping mixed bitshift and bitwise operators in parenthesis to make the precedence between the operators more explicit. While the rules seem clear to me, this is failing CI and simple to address, so this commit adds the recommend parenthesis to fix the failing job.