### PR TITLE
Bump rand crate to 0.9.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/smartiel/rustiq-core"
 [dependencies]
 petgraph = "0.6.3"
 itertools = "0.10.5"
-rand = "0.8.5"
+rand = "0.9.1"

--- a/src/routines/decoding.rs
+++ b/src/routines/decoding.rs
@@ -1,5 +1,5 @@
+use rand::rng;
 use rand::seq::SliceRandom;
-use rand::thread_rng;
 
 pub fn syndrome_decoding(parities: &[Vec<bool>], input_target: &Vec<bool>) -> Option<Vec<bool>> {
     let mut target = input_target.clone();
@@ -56,7 +56,7 @@ fn shuffle_parities(
 ) -> Vec<usize> {
     let n = parities.first().unwrap().len();
     let mut row_permutation: Vec<usize> = (0..parities.len()).collect();
-    row_permutation.shuffle(&mut thread_rng());
+    row_permutation.shuffle(&mut rng());
     let mut new_parities = Vec::new();
     for j in row_permutation.iter() {
         new_parities.push(parities[*j].clone());

--- a/src/routines/f2_linalg.rs
+++ b/src/routines/f2_linalg.rs
@@ -292,14 +292,14 @@ mod tests {
 
     fn random_skinny(n: usize, m: usize) -> Matrix {
         assert!(m <= n);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut matrix = vec![vec![false; m]; n];
         for (i, row) in matrix.iter_mut().take(m).enumerate() {
             row[i] = true;
         }
         for _ in 0..n * n {
-            let i = rng.gen_range(0..n);
-            let j = rng.gen_range(0..n);
+            let i = rng.random_range(0..n);
+            let j = rng.random_range(0..n);
             if i != j {
                 rowop(&mut matrix, i, j);
             }
@@ -375,14 +375,14 @@ mod tests {
     }
 
     fn random_invertible(n: usize) -> Matrix {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut matrix = vec![vec![false; n]; n];
         for (i, row) in matrix.iter_mut().enumerate() {
             row[i] = true;
         }
         for _ in 0..n * n {
-            let i = rng.gen_range(0..n);
-            let j = rng.gen_range(0..n);
+            let i = rng.random_range(0..n);
+            let j = rng.random_range(0..n);
             if i != j {
                 rowop(&mut matrix, i, j);
             }

--- a/src/structures/clifford_circuit.rs
+++ b/src/structures/clifford_circuit.rs
@@ -83,26 +83,26 @@ impl CliffordCircuit {
     }
 
     pub fn random(nqubits: usize, ngates: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut circuit = Self::new(nqubits);
         for _ in 0..ngates {
-            if rng.gen_bool(0.5) {
+            if rng.random_bool(0.5) {
                 // CNOT
-                let i = rng.gen_range(0..nqubits);
-                let mut j = rng.gen_range(0..nqubits);
+                let i = rng.random_range(0..nqubits);
+                let mut j = rng.random_range(0..nqubits);
                 while j == i {
-                    j = rng.gen_range(0..nqubits);
+                    j = rng.random_range(0..nqubits);
                 }
                 circuit.gates.push(CliffordGate::CNOT(i, j));
                 continue;
             }
-            if rng.gen_bool(0.5) {
+            if rng.random_bool(0.5) {
                 // H
-                let i = rng.gen_range(0..nqubits);
+                let i = rng.random_range(0..nqubits);
                 circuit.gates.push(CliffordGate::H(i));
                 continue;
             }
-            let i = rng.gen_range(0..nqubits);
+            let i = rng.random_range(0..nqubits);
             circuit.gates.push(CliffordGate::S(i));
         }
         circuit

--- a/src/structures/graph_state.rs
+++ b/src/structures/graph_state.rs
@@ -16,11 +16,11 @@ impl GraphState {
         }
     }
     pub fn random(n: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut gs = Self::new(n);
         for i in 0..n {
             for j in i..n {
-                let entry = rng.gen::<bool>();
+                let entry = rng.random::<bool>();
                 gs.adj[i][j] = entry;
                 gs.adj[j][i] = entry;
             }

--- a/src/structures/isometry.rs
+++ b/src/structures/isometry.rs
@@ -39,12 +39,12 @@ impl IsometryTableau {
         }
     }
     pub fn random(n: usize, k: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut iso = Self::new(n, k);
         for _ in 0..(n + k) * (n + k) {
-            let i = rng.gen::<usize>() % (n + k);
+            let i = rng.random::<u64>() as usize % (n + k);
             loop {
-                let j = rng.gen::<usize>() % (n + k);
+                let j = rng.random::<u64>() as usize % (n + k);
                 if i == j {
                     continue;
                 }
@@ -52,13 +52,13 @@ impl IsometryTableau {
                 break;
             }
             for _ in 0..(n + k) {
-                let gate_i = rng.gen::<u8>() % 3;
+                let gate_i = rng.random::<u8>() % 3;
                 if gate_i == 1 {
-                    let q = rng.gen::<usize>() % (n + k);
+                    let q = rng.random::<u64>() as usize % (n + k);
                     iso.h(q);
                 }
                 if gate_i == 2 {
-                    let q = rng.gen::<usize>() % (n + k);
+                    let q = rng.random::<u64>() as usize % (n + k);
                     iso.s(q);
                 }
             }

--- a/src/structures/tableau.rs
+++ b/src/structures/tableau.rs
@@ -63,12 +63,12 @@ impl Tableau {
     }
     /// Generates a random Tableau (no garantuees, just here for testing)
     pub fn random(n: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut iso = Self::new(n);
         for _ in 0..(n) * (n) {
-            let i = rng.gen::<usize>() % (n);
+            let i = rng.random::<u64>() as usize % (n);
             loop {
-                let j = rng.gen::<usize>() % (n);
+                let j = rng.random::<u64>() as usize % (n);
                 if i == j {
                     continue;
                 }
@@ -76,13 +76,13 @@ impl Tableau {
                 break;
             }
             for _ in 0..(n) {
-                let gate_i = rng.gen::<u8>() % 3;
+                let gate_i = rng.random::<u8>() % 3;
                 if gate_i == 1 {
-                    let q = rng.gen::<usize>() % (n);
+                    let q = rng.random::<u64>() as usize % (n);
                     iso.h(q);
                 }
                 if gate_i == 2 {
-                    let q = rng.gen::<usize>() % (n);
+                    let q = rng.random::<u64>() as usize % (n);
                     iso.s(q);
                 }
             }

--- a/src/synthesis/clifford/codiagonalization/common.rs
+++ b/src/synthesis/clifford/codiagonalization/common.rs
@@ -121,22 +121,22 @@ mod common_codiag_tests {
     }
     use rand::Rng;
     fn random_instance(n: usize, m: usize) -> PauliSet {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut pset = PauliSet::new(n);
         for _ in 0..m {
             let mut vec: Vec<bool> = vec![false; 2 * n];
             for b in vec.iter_mut().take(n) {
-                *b = rng.gen::<bool>();
+                *b = rng.random::<bool>();
             }
             pset.insert_vec_bool(&vec, false);
         }
         for _ in 0..n * n {
-            let i = rng.gen::<usize>() % n;
+            let i = rng.random::<u64>() as usize % n;
             loop {
-                let j = rng.gen::<usize>() % n;
+                let j = rng.random::<u64>() as usize % n;
                 if j != i {
                     pset.cnot(i, j);
-                    let g2 = rng.gen::<bool>();
+                    let g2 = rng.random::<bool>();
                     if g2 {
                         pset.h(j);
                     } else {
@@ -145,7 +145,7 @@ mod common_codiag_tests {
                     break;
                 }
             }
-            let g1 = rng.gen::<bool>();
+            let g1 = rng.random::<bool>();
             if g1 {
                 pset.h(i);
             } else {

--- a/src/synthesis/clifford/codiagonalization/count.rs
+++ b/src/synthesis/clifford/codiagonalization/count.rs
@@ -117,23 +117,23 @@ mod codiag_count_tests {
     }
     use rand::Rng;
     fn random_instance(n: usize, m: usize) -> PauliSet {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut pset = PauliSet::new(n);
         for _ in 0..m {
             let mut vec: Vec<bool> = vec![false; 2 * n];
             for b in vec.iter_mut().take(n) {
-                *b = rng.gen::<bool>();
+                *b = rng.random::<bool>();
             }
 
             pset.insert_vec_bool(&vec, false);
         }
         for _ in 0..n * n {
-            let i = rng.gen::<usize>() % n;
+            let i = rng.random::<u64>() as usize % n;
             loop {
-                let j = rng.gen::<usize>() % n;
+                let j = rng.random::<u64>() as usize % n;
                 if j != i {
                     pset.cnot(i, j);
-                    let g2 = rng.gen::<bool>();
+                    let g2 = rng.random::<bool>();
                     if g2 {
                         pset.h(j);
                     } else {
@@ -142,7 +142,7 @@ mod codiag_count_tests {
                     break;
                 }
             }
-            let g1 = rng.gen::<bool>();
+            let g1 = rng.random::<bool>();
             if g1 {
                 pset.h(i);
             } else {

--- a/src/synthesis/clifford/codiagonalization/depth.rs
+++ b/src/synthesis/clifford/codiagonalization/depth.rs
@@ -191,22 +191,22 @@ mod codiag_depth_tests {
 
     use rand::Rng;
     fn random_instance(n: usize, m: usize) -> PauliSet {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut pset = PauliSet::new(n);
         for _ in 0..m {
             let mut vec: Vec<bool> = vec![false; 2 * n];
             for b in vec.iter_mut().take(n) {
-                *b = rng.gen::<bool>();
+                *b = rng.random::<bool>();
             }
             pset.insert_vec_bool(&vec, false);
         }
         for _ in 0..n * n {
-            let i = rng.gen::<usize>() % n;
+            let i = rng.random::<u64>() as usize % n;
             loop {
-                let j = rng.gen::<usize>() % n;
+                let j = rng.random::<u64>() as usize % n;
                 if j != i {
                     pset.cnot(i, j);
-                    let g2 = rng.gen::<bool>();
+                    let g2 = rng.random::<bool>();
                     if g2 {
                         pset.h(j);
                     } else {
@@ -215,7 +215,7 @@ mod codiag_depth_tests {
                     break;
                 }
             }
-            let g1 = rng.gen::<bool>();
+            let g1 = rng.random::<bool>();
             if g1 {
                 pset.h(i);
             } else {

--- a/src/synthesis/clifford/codiagonalization/subset_wise.rs
+++ b/src/synthesis/clifford/codiagonalization/subset_wise.rs
@@ -288,7 +288,7 @@ mod codiag_subset_tests {
     use rand::Rng;
     #[test]
     fn test_paper_ex_random_lc() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut x_table = vec![
             vec![false, false, true, true, true, true, false, false],
             vec![false, false, true, true, true, true, false, false],
@@ -299,7 +299,7 @@ mod codiag_subset_tests {
         ];
         for _ in 0..8 {
             for i in 0..2 {
-                let pick = rng.gen::<u8>() % 3;
+                let pick = rng.random::<u8>() % 3;
                 if pick == 1 {
                     for l in 0..8 {
                         x_table[i][l] ^= z_table[i][l];
@@ -314,22 +314,22 @@ mod codiag_subset_tests {
         assert!(matches!(circuit, Some(..)));
     }
     fn random_instance(n: usize, m: usize) -> PauliSet {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut pset = PauliSet::new(n);
         for _ in 0..m {
             let mut vec: Vec<bool> = vec![false; 2 * n];
             for b in vec.iter_mut().take(n) {
-                *b = rng.gen::<bool>();
+                *b = rng.random::<bool>();
             }
             pset.insert_vec_bool(&vec, false);
         }
         for _ in 0..n * n {
-            let i = rng.gen::<usize>() % n;
+            let i = rng.random::<u64>() as usize % n;
             loop {
-                let j = rng.gen::<usize>() % n;
+                let j = rng.random::<u64>() as usize % n;
                 if j != i {
                     pset.cnot(i, j);
-                    let g2 = rng.gen::<bool>();
+                    let g2 = rng.random::<bool>();
                     if g2 {
                         pset.h(j);
                     } else {
@@ -338,7 +338,7 @@ mod codiag_subset_tests {
                     break;
                 }
             }
-            let g1 = rng.gen::<bool>();
+            let g1 = rng.random::<bool>();
             if g1 {
                 pset.h(i);
             } else {

--- a/src/synthesis/clifford/isometry/count.rs
+++ b/src/synthesis/clifford/isometry/count.rs
@@ -207,7 +207,7 @@ mod tests {
     use rand::Rng;
     #[test]
     fn test_graph_state_and_b_synthesis() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let n = 20;
         let mut graph_adj = GraphState::random(n);
         let mut b_matrix: Matrix = vec![vec![false; n]; n];
@@ -216,8 +216,8 @@ mod tests {
         }
 
         for _ in 0..n * n {
-            let i = rng.gen::<usize>() % (n - 1);
-            let j = rng.gen::<usize>() % (n - i - 1) + i + 1;
+            let i = rng.random::<u64>() as usize % (n - 1);
+            let j = rng.random::<u64>() as usize % (n - i - 1) + i + 1;
             assert!(j > i);
             rowop(&mut b_matrix, i, j);
         }
@@ -241,7 +241,7 @@ mod tests {
     }
     #[test]
     fn test_graph_state_and_b_synthesis_rectangular() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let n = 20;
         let k = 5;
         let mut graph_adj = GraphState::random(n + k);
@@ -251,8 +251,8 @@ mod tests {
         }
 
         for _ in 0..(n + k) * (n + k) {
-            let i = rng.gen::<usize>() % (n + k - 1);
-            let j = rng.gen::<usize>() % (n + k - i - 1) + i + 1;
+            let i = rng.random::<u64>() as usize % (n + k - 1);
+            let j = rng.random::<u64>() as usize % (n + k - i - 1) + i + 1;
             assert!(j > i);
             rowop(&mut b_matrix, i, j);
         }

--- a/src/synthesis/clifford/isometry/depth.rs
+++ b/src/synthesis/clifford/isometry/depth.rs
@@ -126,7 +126,7 @@ mod tests {
     }
     #[test]
     fn test_graph_state_and_b_synthesis_rectangular() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let n = 5;
         let k = 5;
         let mut graph = GraphState::random(n + k);
@@ -136,8 +136,8 @@ mod tests {
         }
 
         for _ in 0..(n + k) * (n + k) {
-            let i = rng.gen::<usize>() % (n + k - 1);
-            let j = rng.gen::<usize>() % (n + k - i - 1) + i + 1;
+            let i = rng.random::<u64>() as usize % (n + k - 1);
+            let j = rng.random::<u64>() as usize % (n + k - i - 1) + i + 1;
             assert!(j > i);
             rowop(&mut b_matrix, i, j);
         }

--- a/src/synthesis/pauli_network/synthesis.rs
+++ b/src/synthesis/pauli_network/synthesis.rs
@@ -6,18 +6,18 @@ use crate::structures::{
     CliffordCircuit, CliffordGate, IsometryTableau, Metric, PauliLike, PauliSet,
 };
 use crate::synthesis::clifford::isometry::isometry_synthesis;
-use rand::thread_rng;
+use rand::rng;
 use rand::Rng;
 
 fn permute_input(pset: &mut PauliSet) -> Vec<usize> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut permutation = (0..pset.n).collect::<Vec<usize>>();
     if pset.n <= 1 {
         return permutation;
     }
     for _ in 0..pset.n * pset.n {
-        let i = rng.gen_range(0..pset.n - 1);
-        let j = rng.gen_range(i + 1..pset.n);
+        let i = rng.random_range(0..pset.n - 1);
+        let j = rng.random_range(i + 1..pset.n);
         permutation.swap(i, j);
         pset.swap_qbits(i, j);
     }


### PR DESCRIPTION
This commit bumps the rand version to the latest release, 0.9.1. There were some API deprecations that were updated as part of this change. Additionally, there was an API change around the generation of random usize values. This is no longer supported in rand 0.9.x. So in places where that was used a random u64 is used and that is cast to a u64. This will result in a truncated value on 32 bit platforms, if support for 32 bit platforms is important we can use a config flag to adjust the size of the random integer to use a u32 on 32 bit platforms and a u64 on 64bit platforms. But since there isn't a platform support listed I figured 64bit platforms were the priority and left it as always using a u64.